### PR TITLE
f5: fix error to run ambassador on k3s (environment variable `CONTAIN…

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -52,6 +52,6 @@ ns:
   enable: false
 api-gateway:
   image:
-    tag: 0.51.2
+    tag: 1.13.10
   service:
     type: NodePort


### PR DESCRIPTION
…ERD_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE=1`, but this will be completely removed in containerd v2.1.)